### PR TITLE
Improve the Azure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ providers:
     client_secret: ''
     options:
       scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+      avatar_max_size: 240
   patreon:
     enabled: false
     client_id: ''
@@ -124,6 +125,7 @@ admin:
       client_secret: ''
       options:
         scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+        avatar_max_size: 240
     patreon:
       enabled: false
       client_id: ''
@@ -191,6 +193,7 @@ Note that if you use the admin plugin, a file with your configuration, and named
 |client_id|The **Client ID** Provided by Azure when you register an application for OAuth2 authentication | `<string>` |
 |client_secret|The **Client Secret** Provided by Azure when you register an application for OAuth2 authentication | `<string>` |
 |scope|An array of strings that define the OAuth2 scope. These can enable retrieving more data, but often require more permissions | e.g. `['openid', 'email', 'profile', 'offline_access', 'User.Read']` |
+|avatar_max_size|The maximum size in pixels of the avatar to store. Azure does not provide all sizes, only 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648. | e.g. `240` |
 
 #### Patreon
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ providers:
       scope: ['user_read']
   azure:
     enabled: false
+    tenant: 'common'
     client_id: ''
     client_secret: ''
     options:
-      scope: ['User.Read']
+      scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
   patreon:
     enabled: false
     client_id: ''
@@ -118,10 +119,11 @@ admin:
         scope: ['user_read']
     azure:
       enabled: false
+      tenant: 'common'
       client_id: ''
       client_secret: ''
       options:
-        scope: ['User.Read']
+        scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
     patreon:
       enabled: false
       client_id: ''
@@ -185,9 +187,10 @@ Note that if you use the admin plugin, a file with your configuration, and named
 |Key                   |Description                 | Values |
 |:---------------------|:---------------------------|:-------|
 |enabled|Enable or disable this specific provider. This stops its showing as an valid login option| `true` \| [default: `false`] |
+|tenant|The **Tenant ID** of your Azure AD tenant that you want to use. Use 'common' for all users, 'organizations' for Azure AD work or school accounts, 'consumers' for personal Microsoft accounts or a tenant id for accounts from a single Azure AD tenant.|`common`, `organizations`, `consumers`, e.g. `58673e44-617a-4d61-88b5-fb480759a841`|
 |client_id|The **Client ID** Provided by Azure when you register an application for OAuth2 authentication | `<string>` |
 |client_secret|The **Client Secret** Provided by Azure when you register an application for OAuth2 authentication | `<string>` |
-|scope|An array of strings that define the OAuth2 scope. These can enable retrieving more data, but often require more permissions | e.g. `['User.Read']` |
+|scope|An array of strings that define the OAuth2 scope. These can enable retrieving more data, but often require more permissions | e.g. `['openid', 'email', 'profile', 'offline_access', 'User.Read']` |
 
 #### Patreon
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ providers:
     client_secret: ''
     options:
       scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+      get_groups: false
       avatar_max_size: 240
   patreon:
     enabled: false
@@ -125,6 +126,7 @@ admin:
       client_secret: ''
       options:
         scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+        get_groups: false
         avatar_max_size: 240
     patreon:
       enabled: false
@@ -193,6 +195,7 @@ Note that if you use the admin plugin, a file with your configuration, and named
 |client_id|The **Client ID** Provided by Azure when you register an application for OAuth2 authentication | `<string>` |
 |client_secret|The **Client Secret** Provided by Azure when you register an application for OAuth2 authentication | `<string>` |
 |scope|An array of strings that define the OAuth2 scope. These can enable retrieving more data, but often require more permissions | e.g. `['openid', 'email', 'profile', 'offline_access', 'User.Read']` |
+|get_groups|Add all the groups from Azure to the users, which includes transitive memberships. This needs at least the `GroupMember.Read.All` scope as well, which needs admin consent. **Warning**: if you save the users the groups will only be added, but not removed.| `true` \| [default: `false`] |
 |avatar_max_size|The maximum size in pixels of the avatar to store. Azure does not provide all sizes, only 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648. | e.g. `240` |
 
 #### Patreon

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -570,6 +570,18 @@ form:
                   validate:
                     type: commalist
 
+                providers.azure.options.get_groups:
+                  type: toggle
+                  label: Get groups
+                  help: Add all the groups from Azure to the users, which includes transitive memberships. This needs at least the 'GroupMember.Read.All' scope as well, which needs admin consent.
+                  highlight: 1
+                  default: 0
+                  options:
+                    1: Enabled
+                    0: Disabled
+                  validate:
+                    type: bool
+
                 providers.azure.options.avatar_max_size:
                   type: number
                   size: x-small
@@ -622,6 +634,18 @@ form:
                   classes: fancy
                   validate:
                     type: commalist
+
+                admin.providers.azure.options.get_groups:
+                  type: toggle
+                  label: Get groups
+                  help: Add all the groups from Azure to the users, which includes transitive memberships. This needs at least the 'GroupMember.Read.All' scope as well, which needs admin consent.
+                  highlight: 1
+                  default: 0
+                  options:
+                    1: Enabled
+                    0: Disabled
+                  validate:
+                    type: bool
 
                 admin.providers.azure.options.avatar_max_size:
                   type: number

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -549,6 +549,11 @@ form:
                   validate:
                     type: bool
 
+                providers.azure.tenant:
+                  type: text
+                  label: Tenant ID
+                  help: Use 'common' for all users, 'organizations' for Azure AD work or school accounts, 'consumers' for personal Microsoft accounts or a tenant id for accounts from a single Azure AD tenant.
+
                 providers.azure.client_id:
                   type: text
                   label: PLUGIN_LOGIN_OAUTH2.CLIENT_ID
@@ -585,6 +590,11 @@ form:
                     0: Disabled
                   validate:
                     type: bool
+
+                admin.providers.azure.tenant:
+                  type: text
+                  label: Tenant ID
+                  help: Use 'common' for all users, 'organizations' for Azure AD work or school accounts, 'consumers' for personal Microsoft accounts or a tenant id for accounts from a single Azure AD tenant.
 
                 admin.providers.azure.client_id:
                   type: text

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -570,6 +570,17 @@ form:
                   validate:
                     type: commalist
 
+                providers.azure.options.avatar_max_size:
+                  type: number
+                  size: x-small
+                  append: px
+                  label: Maximum avatar size
+                  help: Azure does not provide all sizes, only certain pre-defined ones. The minimum size is 48px, the maximum 648px.
+                  validate:
+                    type: number
+                    min: 48
+                    max: 648
+
             azure_column_right:
               type: column
 
@@ -611,6 +622,17 @@ form:
                   classes: fancy
                   validate:
                     type: commalist
+
+                admin.providers.azure.options.avatar_max_size:
+                  type: number
+                  size: x-small
+                  append: px
+                  label: Maximum avatar size
+                  help: Azure does not provide all sizes, only certain pre-defined ones. The minimum size is 48px, the maximum 648px.
+                  validate:
+                    type: number
+                    min: 48
+                    max: 648
 
         providers.azure.description:
           type: display

--- a/classes/Providers/AzureProvider.php
+++ b/classes/Providers/AzureProvider.php
@@ -1,6 +1,9 @@
 <?php
 namespace Grav\Plugin\Login\OAuth2\Providers;
 
+use Grav\Common\Grav;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+
 class AzureProvider extends ExtraProvider
 {
     protected $name = 'Azure';
@@ -12,6 +15,9 @@ class AzureProvider extends ExtraProvider
             'clientId'      => $this->config->get('providers.azure.client_id'),
             'clientSecret'  => $this->config->get('providers.azure.client_secret'),
             'tenant'        => $this->config->get('providers.azure.tenant'),
+            // Get access tokens for the Microsoft Graph API instead of the old Azure AD Graph.
+            'urlAPI'        => 'https://graph.microsoft.com',
+            'resource'      => 'https://graph.microsoft.com',
             'redirectUri'   => $this->getCallbackUri(),
         ];
 
@@ -28,17 +34,88 @@ class AzureProvider extends ExtraProvider
 
     public function getUserData($user)
     {
+        $name = $user->claim('name');
         $data_user = [
             'id'         => $user->getId(),
             'login'      => $user->getUpn(),
-            'fullname'   => $user->claim('name'),
+            'fullname'   => $name,
             'email'      => $user->claim('email') ?: $user->getUpn(),
             'azure'      => [
+                // The avatar can be set by using avatar_url or avatar.
+                // Technically we're not setting a url because pictures from Azure are not public, so this contains a
+                // data url with a base64 encoded image.
+                'avatar' => $this->getAvatar($name),
                 'issuer' => $user->claim('iss'),
                 'tenant' => $user->getTenantId(),
             ]
         ];
 
         return $data_user;
+    }
+
+    public function getAvatar($name)
+    {
+        $avatarMaxSize = $this->config->get('providers.azure.options.avatar_max_size');
+        // This should already be validated to be at least 48, because that's the lowest available resolution, but just
+        // to be sure.
+        if ($avatarMaxSize < 48)
+        {
+            $avatarMaxSize = 48;
+        }
+
+        // First get the meta information for all the available pictures, there are versions from 48x48 to 648x648,
+        // depending on the size uploaded by the user.
+        // Use the beta endpoint to get the profile picture as the v1.0 endpoint only returns the picture if the user
+        // has a mailbox. See https://docs.microsoft.com/en-us/graph/known-issues#users
+        $photoMetaUrl = 'https://graph.microsoft.com/beta/me/photos/';
+        try
+        {
+            $photoMetaList = $this->provider->get($photoMetaUrl, $this->token);
+        }
+        catch (IdentityProviderException $e)
+        {
+            // User seems to have no picture.
+            Grav::instance()['log']->info('AzureProvider: failed to get photo for user \'' . $name .
+                '\'. Exception message: ' . $e->getMessage());
+            return null;
+        }
+
+        // Limit picture size by width or height, depending on which is larger.
+        $comparisonProperty = $photoMetaList[0]['height'] > $photoMetaList[0]['width'] ? 'height' : 'width';
+
+        // Filter pictures by maximum size that was configured.
+        $photoMetaList = array_filter(
+            $photoMetaList,
+            function ($photoMeta) use ($comparisonProperty, $avatarMaxSize)
+            {
+                return $photoMeta[$comparisonProperty] <= $avatarMaxSize;
+            }
+        );
+
+        // Get the metadata for the largest remaining picture.
+        $photoMeta = array_reduce(
+            $photoMetaList,
+            function($carry, $item) use ($comparisonProperty){
+                return $carry[$comparisonProperty] < $item[$comparisonProperty] ? $item : $carry;
+            },
+            [$comparisonProperty => -PHP_INT_MAX]
+        );
+
+        // Get the actual picture.
+        $photoUrl = $photoMetaUrl . $photoMeta['id'] . '/$value';
+        try
+        {
+            $photo = $this->provider->get($photoUrl, $this->token);
+        }
+        catch (IdentityProviderException $e)
+        {
+            // Getting the picture failed even though getting the meta succeeded.
+            Grav::instance()['log']->error('AzureProvider: failed to get photo for user \'' . $name .
+                '\'. Exception message: ' . $e->getMessage());
+            return null;
+        }
+
+        // Use a data url with a base64 encoded image since we need to provide a url for the avatar.
+        return 'data:' . $photoMeta['@odata.mediaContentType'] . ';base64,' . base64_encode($photo);
     }
 }

--- a/classes/Providers/AzureProvider.php
+++ b/classes/Providers/AzureProvider.php
@@ -11,6 +11,7 @@ class AzureProvider extends ExtraProvider
         $options += [
             'clientId'      => $this->config->get('providers.azure.client_id'),
             'clientSecret'  => $this->config->get('providers.azure.client_secret'),
+            'tenant'        => $this->config->get('providers.azure.tenant'),
             'redirectUri'   => $this->getCallbackUri(),
         ];
 
@@ -30,8 +31,12 @@ class AzureProvider extends ExtraProvider
         $data_user = [
             'id'         => $user->getId(),
             'login'      => $user->getUpn(),
-            'fullname'   => $user->getFirstName() . " " . $user->getLastName(),
-            'email'      => $user->getUpn()
+            'fullname'   => $user->claim('name'),
+            'email'      => $user->claim('email') ?: $user->getUpn(),
+            'azure'      => [
+                'issuer' => $user->claim('iss'),
+                'tenant' => $user->getTenantId(),
+            ]
         ];
 
         return $data_user;

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "omines/oauth2-gitlab": "^3.1",
         "depotwarehouse/oauth2-twitch": "^1.3",
         "thenetworg/oauth2-azure": "^1.4",
-        "gravure/oauth2-patreon": "dev-master"
+        "gravure/oauth2-patreon": "dev-master",
+        "guzzlehttp/promises": "^1.3"
     },
     "replace": {
         "league/oauth2-client": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9244b56835e48858dc2e38959aff262",
+    "content-hash": "351b7c3068e62966776d032e443a1901",
     "packages": [
         {
             "name": "adam-paterson/oauth2-slack",

--- a/login-oauth2-extras.yaml
+++ b/login-oauth2-extras.yaml
@@ -39,6 +39,7 @@ providers:
     client_secret: ''
     options:
       scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+      get_groups: false
       avatar_max_size: 240
   patreon:
     enabled: false
@@ -89,6 +90,7 @@ admin:
       client_secret: ''
       options:
         scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+        get_groups: false
         avatar_max_size: 240
     patreon:
       enabled: false

--- a/login-oauth2-extras.yaml
+++ b/login-oauth2-extras.yaml
@@ -39,6 +39,7 @@ providers:
     client_secret: ''
     options:
       scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+      avatar_max_size: 240
   patreon:
     enabled: false
     client_id: ''
@@ -88,6 +89,7 @@ admin:
       client_secret: ''
       options:
         scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
+        avatar_max_size: 240
     patreon:
       enabled: false
       client_id: ''

--- a/login-oauth2-extras.yaml
+++ b/login-oauth2-extras.yaml
@@ -34,10 +34,11 @@ providers:
       scope: ['user_read']
   azure:
     enabled: false
+    tenant: 'common'
     client_id: ''
     client_secret: ''
     options:
-      scope: ['User.Read']
+      scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
   patreon:
     enabled: false
     client_id: ''
@@ -82,10 +83,11 @@ admin:
         scope: ['user_read']
     azure:
       enabled: false
+      tenant: 'common'
       client_id: ''
       client_secret: ''
       options:
-        scope: ['User.Read']
+        scope: ['openid', 'email', 'profile', 'offline_access', 'User.Read']
     patreon:
       enabled: false
       client_id: ''


### PR DESCRIPTION
This adds or changes the following features:
- Allow configuring a tenant for controlling which kinds of users can connect and to generate better login urls.
- Add the default OpenID Connect scopes for Azure for more information in the tokens, like the actual email address.
- Get the profile picture from Azure, max size can be configured.
- Optionally get the groups from Azure.

Other than other identity providers, Azure does not provide public urls to the profile pictures, because in many cases they will be private pictures of organization members. Grav only accepts urls to the picture from oauth2 identity providers, therefore this creates and returns a data url with a base64 encoded image. I'm not sure if there's a better way for this, I couldn't find one to properly create a profile image from the provider in an easy way. There is also a problem with this when using the admin plugin, unless a url already includes a question mark, which these do not, it adds a size parameter for the sidebar image, which breaks the base64 data. See getgrav/grav-plugin-admin#1889.

The groups include transitive memberships. The first request to the Microsoft Graph API returns only the guids of the groups, therefore one additional request has to be made for each group to get the name. To make sure this doesn't slow down the login process for users with many group memberships, the requests are run in parallel by using Guzzle promises, because that's the library that the oauth2-client library by league uses. oauth2-client does not provide parallel requests though. It would be better if this logic would be implemented in the lower level libraries, but it works for now.

**Important notes** about the group syncronization:
- Since the groups get returned under the group key in the data_user array, which gets merged into the existing user, groups will only be added to a user, but not deleted. Just like the profile pictures I didn't find a good way to also delete them when they're not present anymore, without also changing the login-oauth2 plugin. As a workaround saving users can be turned off.
- The groups will only be mapped to the user, to give them access rights and make sure they're displayed in the admin plugin they need to be manually created once.